### PR TITLE
Update community pools idl import

### DIFF
--- a/src/pools/contract_model/accounts.ts
+++ b/src/pools/contract_model/accounts.ts
@@ -10,7 +10,7 @@ import {
   SecondStakeAccountView,
   SecondaryRewardView
 } from '../types';
-import idl from '../../common/idl/multi_reward_staking.json';
+import idl from '../contract_model/idl/community_pools_anchor.json';
 
 export const returnCommunityPoolsAnchorProgram = async (
   programId: web3.PublicKey,


### PR DESCRIPTION
`pools.getAllProgramAccounts` was failing due to an error and looks like the incorrect idl was being imported here. I was able to successfully call `pools.getAllProgramAccounts` after making this change.